### PR TITLE
Update version to 4.2.0 - Flynn

### DIFF
--- a/avmlog.go
+++ b/avmlog.go
@@ -17,7 +17,7 @@ import (
 // Time layouts must use the reference time `Mon Jan 2 15:04:05 MST 2006` to
 // convey the pattern with which to format/parse a given time/string
 const TIME_LAYOUT string = "[2006-01-02 15:04:05 MST]"
-const VERSION = "v4.1.0 - Flash"
+const VERSION = "v4.2.0 - Flynn"
 const BUFFER_SIZE = bufio.MaxScanTokenSize
 
 const REPORT_HEADERS = "RequestID, Method, URL, Computer, User, Request Result, Request Start, Request End, Request Time (ms), Db Time (ms), View Time (ms), Mount Time (ms), % Request Mounting, Mount Result, Errors, ESX-A, VC-A, Con+, Con-"


### PR DESCRIPTION
Updating the version from 4.1.0 to 4.2.0 to account for the new change to regex for "allocations". I will help with compiling and making a release if necessary. As I don't have write access anymore, someone can just follow the instructions in the readme as well.

go is now:
go version go1.21.5 darwin/amd64

The last release was with go1.18.5 darwin/amd64